### PR TITLE
Bugfix: Create directory if not exists, Feature addition: pastebin-based installer

### DIFF
--- a/programs/github
+++ b/programs/github
@@ -30,6 +30,7 @@ if action == 'clone' then
 	if not (user and repo) then return printError("Invalid repo name - should be user/repo") end
 
 	dest = shell.resolve(dest or repo)
+  if not fs.isDir(dest) then fs.makeDir(dest)
 
 	-- get file listings
 	local repo = github.repo(user, repo)

--- a/programs/github-install
+++ b/programs/github-install
@@ -1,0 +1,50 @@
+--[[
+-- Github install
+-- For those of us who are limited to pastebin gets, this installer will
+-- download github and the APIs to the correct locations.
+-- Usage: pastebin get 5XJCYuJ8 github-install
+--        github-install
+--]]
+
+function getUrlFile(url)
+  local mrHttpFile = http.get(url)
+  mrHttpFile = mrHttpFile.readAll()
+  return mrHttpFile
+end
+
+function writeFile(filename, data, dir)
+  dir = dir or false
+  if dir then
+    if not fs.isDir(dir) then fs.makeDir(dir) end
+    filename = dir.."/"..filename
+  end
+  local file = fs.open(filename, "w")
+  file.write(data)
+  file.close()
+end
+
+term.clear()
+
+term.setCursorPos(1,5)
+write("-> Getting dkjson API...")
+program = getUrlFile("https://raw.github.com/ogredude/computercraft-github/master/apis/dkjson")
+writeFile('dkjson', program, 'apis')
+write(" Done.")
+
+term.setCursorPos(1,6)
+write("-> Getting github API...")
+program = getUrlFile("https://raw.github.com/ogredude/computercraft-github/master/apis/github")
+writeFile('github', program, 'apis')
+write(" Done.")
+
+term.setCursorPos(1,7)
+write("-> Getting github...")
+program = getUrlFile("https://raw.github.com/ogredude/computercraft-github/master/programs/github")
+writeFile('github', program)
+write(" Done.")
+
+term.setCursorPos(1,8)
+print("Congratulations. Github is installed.")
+print("Usage: github clone <user>/<repository> [destination]")
+print("Destination is optional and defaults to the repository name.")
+print("WARNING: This script will happily overwrite any existing files!")


### PR DESCRIPTION
Hi,

I've been looking for a way to manage my computercraft development through github, because quite honestly the whole "copy -> paste to pastebin -> delete file on in-game computer -> type in the stupid untypeable code into the computer again"  development cycle was filling me with rage.

I found your project to be the first one that reliably pulls from github. Thanks for building it! Now my workflow is so much more comfortable.  Work -> Commit -> Push -> Clone. Nearly normal!

I noticed that when you clone a repo, if the destination directory doesn't already exist, it simply creates the directory and doesn't actually download anything.

I've got that fixed, it now creates the destination directory before trying to download if the destination directory doesn't exist.

I also cooked up an installer for those of us with only pastebin access to our computercraft computers. It's set to my fork of this project, you'll want to change that for yours.

