### PR TITLE
Fetch tree and blob contents lazily

### DIFF
--- a/apis/github
+++ b/apis/github
@@ -76,48 +76,81 @@ Blob.fullPath = function(self)
 		return self.path
 	end
 end
+Blob.getContents = function(self)
+	local data = http.get(
+		('https://raw.github.com/%s/%s/%s/%s'):format(
+			self.repo.user, self.repo.name, self.sha,
+			encodeURI(self:fullPath())
+		)
+	)
+	return data.readAll()
+end
 
 -- A class for a tree (aka a folder)
 local Tree = {}
 Tree.__index = Tree
 Tree.new = function(repo, sha, path)
-	local url = ('repos/%s/%s/git/trees/%s'):format(repo.user, repo.name, sha)
-	local status, data = getAPI(url, repo.auth)
+	return setmetatable({
+		repo = repo,
+		sha = sha,
+		path = path or ''
+	}, Tree)
+end
+Tree.getContents = function(self)
+	if self.contents then
+		return self.contents
+	end
+
+	local url = ('repos/%s/%s/git/trees/%s'):format(self.repo.user, self.repo.name, self.sha)
+	local status, data = getAPI(url, self.repo.auth)
 	if not status then
 		error('Could not get github API from ' ..url)
 	end
 	if data.tree then
-		local tree = setmetatable({
-			repo=repo, sha=data.sha,
-			path=path or '', size=0,
-			contents={}
-		}, Tree)
+		self.sha = data.sha
+		self.size = 0
+		self.contents = {}
 		for _, childdata in ipairs(data.tree) do
-			childdata.fullPath = fs.combine(tree:fullPath(), childdata.path)
+			childdata.fullPath = fs.combine(self:fullPath(), childdata.path)
 			local child
 			if childdata.type == 'blob' then
-				child = Blob.new(repo, childdata.sha, childdata.path)
+				child = Blob.new(self.repo, childdata.sha, childdata.path)
 				child.size = childdata.size
 			elseif childdata.type == 'tree' then
-				child = Tree.new(repo, childdata.sha, childdata.path)
+				child = Tree.new(self.repo, childdata.sha, childdata.path)
 			else
-				error("uh oh", JSON.encode(childdata))
-				child = childdata
+				error("Unknown tree node type", JSON.encode(childdata))
 			end
-			tree.size = tree.size + child.size
-			child.parent = tree
-			table.insert(tree.contents, child)
+			self.size = self.size + (child.size or 0)
+			child.parent = self
+			table.insert(self.contents, child)
 		end
-		return tree
+		return self.contents
 	else
-		error("uh oh", JSON.encode(data))
+		error("No tree data returned", JSON.encode(data))
 	end
 end
 local function walkTree(t, level)
-	for _, item in ipairs(t.contents) do
+	for _, item in ipairs(t:getContents()) do
 		coroutine.yield(item, level)
 		if getmetatable(item) == Tree then
 			walkTree(item, level + 1)
+		end
+	end
+end
+Tree.getFullSize = function(self)
+	local size = 0
+	for item in self:iter() do
+		if getmetatable(item) == Blob then
+			size = size + item.size
+		end
+	end
+	return size
+end
+Tree.getChild = function(self, path)
+	for _, item in ipairs(self:getContents()) do
+		if item.path == path then
+			return item
 		end
 	end
 end
@@ -134,19 +167,12 @@ Tree.cloneTo = function(self, dest, onProgress)
 	end
 
 	for item in self:iter() do
-		local gitpath = item:fullPath()
-		local path = fs.combine(dest, gitpath)
+		local path = fs.combine(dest, item:fullPath())
 		if getmetatable(item) == Tree then
 			fs.makeDir(path)
 		elseif getmetatable(item) == Blob then
-			local data = http.get(
-				('https://raw.github.com/%s/%s/%s/%s'):format(
-					self.repo.user, self.repo.name, self.sha,
-					encodeURI(gitpath)
-				)
-			)
+			local text = item:getContents()
 			local h = fs.open(path, 'w')
-			local text = data.readAll()
 			h.write(text)
 			h.close()
 		end


### PR DESCRIPTION
Closes #26.

This PR necessarily introduces a small breaking change - `Tree.size` no longer represents the total size of all files in the tree, only the total size of the files at the top level. `Tree:getFullSize` is introduced to return what `Tree.size` originally did.

In addition to `Blob:getContents` and `Tree:getContents`, a convenience method `Tree:getChild` has also been added.