### PR TITLE
Support for GitHub commits

### DIFF
--- a/apis/github
+++ b/apis/github
@@ -63,6 +63,25 @@ Auth.delete = function(user)
 	writeAuth(authTable)
 end
 
+-- A class for a commit
+local Commit = {}
+Commit.__index = Commit
+Commit.new = function(repo, sha)
+	-- Documented here: https://developer.github.com/v3/git/trees/
+	local url = ('repos/%s/%s/git/commits/%s'):format(repo.user, repo.name, sha)
+	local status, data = getAPI(url, repo.auth)
+	if not status then
+		error('Could not get commit github API from ' ..url)
+	end
+	return setmetatable({
+		repo = repo,
+		sha = sha,
+		author = data.author,
+		committer = data.committer,
+		message = data.message
+	}, Commit)
+end
+
 -- A class for a blob (aka a file)
 local Blob = {}
 Blob.__index = Blob
@@ -121,6 +140,9 @@ local function walkTree(t, level)
 		end
 	end
 end
+Tree.getCommit = function(self)
+	return Commit.new(self.repo, self.sha)
+end
 Tree.iter = function(self)
 	return coroutine.wrap(function()
 		walkTree(self, 0)
@@ -176,6 +198,7 @@ Repository.__tostring = function(self) return ("Repo@%s/%s"):format(self.user, s
 -- Export members
 local github = {}
 github.Repository = Repository
+github.Commit = Commit
 github.Blob = Blob
 github.Tree = Tree
 github.Auth = Auth


### PR DESCRIPTION
Closes #30.

Adds a new `Commit` class and a `Tree:getCommit` method.

Technically, a Git commit owns/references a Git tree rather than vice-versa, but the GitHub API doesn't quite work that way: you can `GET /repos/:owner/:repo/git/trees/:commit_ish`, but strangely, commit-ishes don't work with the commits API; `GET /repos/:owner/:repo/git/commits/master` fails with a 404. Plus restructuring the Lua API to have `Commit` own `Tree` would probably have broken backwards compatibility in a number of ways, so I just made the minimal number of changes to make this feature work.

This could be merged now, but `Tree:getCommit` will require corrections if merged after #27, because `self.sha` may still be set to a commit-ish rather than a SHA before `Tree:getContents` is called.

Going to test this out a bit before I mark it ready for review.