### PR TITLE
Fetch tree contents recursively

### DIFF
--- a/apis/github
+++ b/apis/github
@@ -89,11 +89,12 @@ end
 -- A class for a tree (aka a folder)
 local Tree = {}
 Tree.__index = Tree
-Tree.new = function(repo, sha, path)
+Tree.new = function(repo, sha, path, treeSha)
 	return setmetatable({
 		repo = repo,
 		sha = sha,
-		path = path or ''
+		path = path or '',
+		treeSha = treeSha
 	}, Tree)
 end
 Tree.getContents = function(self)
@@ -101,23 +102,27 @@ Tree.getContents = function(self)
 		return self.contents
 	end
 
-	local url = ('repos/%s/%s/git/trees/%s'):format(self.repo.user, self.repo.name, self.sha)
+	local url = ('repos/%s/%s/git/trees/%s'):format(self.repo.user, self.repo.name, self.treeSha or self.sha)
 	local status, data = getAPI(url, self.repo.auth)
 	if not status then
-		error('Could not get github API from ' ..url)
+		error('Could not get github API from ' .. url)
 	end
 	if data.tree then
-		self.sha = data.sha
+		-- Overwrite pseudo-SHAs like tag or branch names with actual SHAs.
+		if not self.treeSha then
+			self.sha = data.sha
+			self.treeSha = data.sha
+		end
 		self.size = 0
 		self.contents = {}
 		for _, childdata in ipairs(data.tree) do
 			childdata.fullPath = fs.combine(self:fullPath(), childdata.path)
 			local child
 			if childdata.type == 'blob' then
-				child = Blob.new(self.repo, childdata.sha, childdata.path)
+				child = Blob.new(self.repo, self.sha, childdata.path)
 				child.size = childdata.size
 			elseif childdata.type == 'tree' then
-				child = Tree.new(self.repo, childdata.sha, childdata.path)
+				child = Tree.new(self.repo, self.sha, childdata.path, childdata.sha)
 			else
 				error("Unknown tree node type", JSON.encode(childdata))
 			end

--- a/apis/github
+++ b/apis/github
@@ -98,8 +98,8 @@ Tree.new = function(repo, sha, path, treeSha)
 	}, Tree)
 end
 Tree.getContents = function(self)
-	if self.contents then
-		return self.contents
+	if self._contents then
+		return self._contents
 	end
 
 	local url = ('repos/%s/%s/git/trees/%s'):format(self.repo.user, self.repo.name, self.treeSha or self.sha)
@@ -114,7 +114,7 @@ Tree.getContents = function(self)
 			self.treeSha = data.sha
 		end
 		self.size = 0
-		self.contents = {}
+		self._contents = {}
 		for _, childdata in ipairs(data.tree) do
 			childdata.fullPath = fs.combine(self:fullPath(), childdata.path)
 			local child
@@ -128,9 +128,9 @@ Tree.getContents = function(self)
 			end
 			self.size = self.size + (child.size or 0)
 			child.parent = self
-			table.insert(self.contents, child)
+			table.insert(self._contents, child)
 		end
-		return self.contents
+		return self._contents
 	else
 		error("No tree data returned", JSON.encode(data))
 	end

--- a/apis/github
+++ b/apis/github
@@ -130,14 +130,6 @@ Tree.getContents = function(self)
 		error("No tree data returned", JSON.encode(data))
 	end
 end
-local function walkTree(t, level)
-	for _, item in ipairs(t:getContents()) do
-		coroutine.yield(item, level)
-		if getmetatable(item) == Tree then
-			walkTree(item, level + 1)
-		end
-	end
-end
 Tree.getFullSize = function(self)
 	local size = 0
 	for item in self:iter() do
@@ -155,9 +147,18 @@ Tree.getChild = function(self, path)
 	end
 end
 Tree.iter = function(self)
-	return coroutine.wrap(function()
-		walkTree(self, 0)
-	end)
+	local stack = {{self, 0}}
+	return function()
+		local entry = table.remove(stack)
+		if entry then
+			if getmetatable(entry[1]) == Tree then
+				for _, child in ipairs(entry[1]:getContents()) do
+					table.insert(stack, {child, entry[2] + 1})
+				end
+			end
+			return unpack(entry)
+		end
+	end
 end
 Tree.cloneTo = function(self, dest, onProgress)
 	if not fs.exists(dest) then

--- a/apis/github
+++ b/apis/github
@@ -76,48 +76,81 @@ Blob.fullPath = function(self)
 		return self.path
 	end
 end
+Blob.getContents = function(self)
+	local data = http.get(
+		('https://raw.github.com/%s/%s/%s/%s'):format(
+			self.repo.user, self.repo.name, self.sha,
+			encodeURI(self:fullPath())
+		)
+	)
+	return data.readAll()
+end
 
 -- A class for a tree (aka a folder)
 local Tree = {}
 Tree.__index = Tree
 Tree.new = function(repo, sha, path)
-	local url = ('repos/%s/%s/git/trees/%s'):format(repo.user, repo.name, sha)
-	local status, data = getAPI(url, repo.auth)
+	return setmetatable({
+		repo = repo,
+		sha = sha,
+		path = path or ''
+	}, Tree)
+end
+Tree.getContents = function(self)
+	if self.contents then
+		return self.contents
+	end
+
+	local url = ('repos/%s/%s/git/trees/%s'):format(self.repo.user, self.repo.name, self.sha)
+	local status, data = getAPI(url, self.repo.auth)
 	if not status then
 		error('Could not get github API from ' ..url)
 	end
 	if data.tree then
-		local tree = setmetatable({
-			repo=repo, sha=data.sha,
-			path=path or '', size=0,
-			contents={}
-		}, Tree)
+		self.sha = data.sha
+		self.size = 0
+		self.contents = {}
 		for _, childdata in ipairs(data.tree) do
-			childdata.fullPath = fs.combine(tree:fullPath(), childdata.path)
+			childdata.fullPath = fs.combine(self:fullPath(), childdata.path)
 			local child
 			if childdata.type == 'blob' then
-				child = Blob.new(repo, childdata.sha, childdata.path)
+				child = Blob.new(self.repo, childdata.sha, childdata.path)
 				child.size = childdata.size
 			elseif childdata.type == 'tree' then
-				child = Tree.new(repo, childdata.sha, childdata.path)
+				child = Tree.new(self.repo, childdata.sha, childdata.path)
 			else
-				error("uh oh", JSON.encode(childdata))
-				child = childdata
+				error("Unknown tree node type", JSON.encode(childdata))
 			end
-			tree.size = tree.size + child.size
-			child.parent = tree
-			table.insert(tree.contents, child)
+			self.size = self.size + (child.size or 0)
+			child.parent = self
+			table.insert(self.contents, child)
 		end
-		return tree
+		return self.contents
 	else
-		error("uh oh", JSON.encode(data))
+		error("No tree data returned", JSON.encode(data))
 	end
 end
 local function walkTree(t, level)
-	for _, item in ipairs(t.contents) do
+	for _, item in ipairs(t:getContents()) do
 		coroutine.yield(item, level)
 		if getmetatable(item) == Tree then
 			walkTree(item, level + 1)
+		end
+	end
+end
+Tree.getFullSize = function(self)
+	local size = 0
+	for item in self:iter() do
+		if getmetatable(item) == Blob then
+			size = size + item.size
+		end
+	end
+	return size
+end
+Tree.getChild = function(self, path)
+	for _, item in ipairs(self:getContents()) do
+		if item.path == path then
+			return item
 		end
 	end
 end
@@ -134,19 +167,12 @@ Tree.cloneTo = function(self, dest, onProgress)
 	end
 
 	for item in self:iter() do
-		local gitpath = item:fullPath()
-		local path = fs.combine(dest, gitpath)
+		local path = fs.combine(dest, item:fullPath())
 		if getmetatable(item) == Tree then
 			fs.makeDir(path)
 		elseif getmetatable(item) == Blob then
-			local data = http.get(
-				('https://raw.github.com/%s/%s/%s/%s'):format(
-					self.repo.user, self.repo.name, self.sha,
-					encodeURI(gitpath)
-				)
-			)
+			local text = item:getContents()
 			local h = fs.open(path, 'w')
-			local text = data.readAll()
 			h.write(text)
 			h.close()
 		end

--- a/apis/github
+++ b/apis/github
@@ -97,15 +97,41 @@ Tree.new = function(repo, sha, path, treeSha)
 		treeSha = treeSha
 	}, Tree)
 end
+local function getTreeAPI(tree, recursive)
+	local url = ('repos/%s/%s/git/trees/%s'):format(tree.repo.user, tree.repo.name, tree.treeSha or tree.sha)
+	if recursive then
+		url = url .. '?recursive=true'
+	end
+	local status, data = getAPI(url, tree.repo.auth)
+	if not status then
+		error('Could not get github tree API from ' .. url)
+	end
+	return data
+end
+local function getParent(tree, childPath)
+	local parent, child = childPath:match("([^/]+)/(.+)")
+	if parent then
+		local parentTree = tree:getChild(parent)
+		if getmetatable(parentTree) == Tree then
+			return getParent(parentTree, child)
+		else
+			error(parent .. ' is not a tree')
+		end
+	else
+		return tree, childPath
+	end
+end
 Tree.getContents = function(self)
 	if self._contents then
 		return self._contents
 	end
 
-	local url = ('repos/%s/%s/git/trees/%s'):format(self.repo.user, self.repo.name, self.treeSha or self.sha)
-	local status, data = getAPI(url, self.repo.auth)
-	if not status then
-		error('Could not get github API from ' .. url)
+	local recursive = true
+	local data = getTreeAPI(self, recursive)
+	if data.truncated then
+		-- Very rare; would only occur on the largest of repositories.
+		recursive = false
+		data = getTreeAPI(self, recursive)
 	end
 	if data.tree then
 		-- Overwrite pseudo-SHAs like tag or branch names with actual SHAs.
@@ -116,19 +142,24 @@ Tree.getContents = function(self)
 		self.size = 0
 		self._contents = {}
 		for _, childdata in ipairs(data.tree) do
-			childdata.fullPath = fs.combine(self:fullPath(), childdata.path)
+			local parent, childPath = getParent(self, childdata.path)
+			childdata.fullPath = fs.combine(parent:fullPath(), childPath)
 			local child
 			if childdata.type == 'blob' then
-				child = Blob.new(self.repo, self.sha, childdata.path)
+				child = Blob.new(self.repo, self.sha, childPath)
 				child.size = childdata.size
 			elseif childdata.type == 'tree' then
-				child = Tree.new(self.repo, self.sha, childdata.path, childdata.sha)
+				child = Tree.new(self.repo, self.sha, childPath, childdata.sha)
+				if recursive then
+					child.size = 0
+					child._contents = {}
+				end
 			else
 				error("Unknown tree node type", JSON.encode(childdata))
 			end
-			self.size = self.size + (child.size or 0)
-			child.parent = self
-			table.insert(self._contents, child)
+			parent.size = parent.size + (child.size or 0)
+			child.parent = parent
+			table.insert(parent._contents, child)
 		end
 		return self._contents
 	else

--- a/programs/github
+++ b/programs/github
@@ -147,7 +147,7 @@ if action == subcommands.clone then
 	local tree = repo:tree(treeName)
 
 	-- download the files
-	local totalSize = tree.size
+	local totalSize = tree:getFullSize()
 	local freeSpace = fs.getFreeSpace(dest)
 
 	if not hasEnoughSpace(totalSize, freeSpace) then


### PR DESCRIPTION
Based on #27; can rebase if/when that is merged.

This uses the `recursive` parameter on the [GitHub trees API](https://developer.github.com/v3/git/trees/#get-a-tree) to eliminate all subtree API requests - a clone operation now requires just one trees API request and `raw.github.com` requests for each of the blobs.

Theoretically, the response to a recursive trees API request could be too large and get truncated; the code handles that case, but practically speaking, that code path will likely never be used, since even https://github.com/kubernetes/kubernetes/tree/master can be fetched in a single recursive trees API request - any repository used for ComputerCraft is likely to be much smaller than that.