### PR TITLE
Use textutils.urlEncode rather than rolling our own

### DIFF
--- a/apis/github
+++ b/apis/github
@@ -16,7 +16,7 @@ local function getAPI(path, auth)
 end
 
 local function encodeURI(s)
-	return s:gsub(' ', '%%20')
+	return s:gsub('([^/]+)', textutils.urlEncode)
 end
 
 -- A class for authorization


### PR DESCRIPTION
Update local function `encodeURI` (which doesn't handle all necessary substitutions) to use built-in `textutils.urlEncode`.